### PR TITLE
Use innerText to avoid issues copying HTML entities

### DIFF
--- a/CodeCopy.vue
+++ b/CodeCopy.vue
@@ -59,7 +59,7 @@ export default {
         },
         copyToClipboard(el) {
             navigator.clipboard
-                .writeText(this.code.replace(/<[^>]*>?/gm, ''))
+                .writeText(this.code)
                 .then(
                     () => {
                         clearTimeout(this.successTimeout)

--- a/clientRootMixin.js
+++ b/clientRootMixin.js
@@ -22,7 +22,7 @@ export default {
                         successText: successText
                     }
                     instance.options = { ...options }
-                    instance.code = el.innerHTML
+                    instance.code = el.innerText
                     instance.parent = el
                     instance.$mount()
                     el.classList.add('code-copy-added')


### PR DESCRIPTION
As per https://github.com/znicholasbrown/vuepress-plugin-code-copy/issues/1