### PR TITLE
Add Option for Copy Icon to Remain Static

### DIFF
--- a/CodeCopy.vue
+++ b/CodeCopy.vue
@@ -28,7 +28,8 @@ export default {
             color: String,
             backgroundTransition: Boolean,
             backgroundColor: String,
-            successText: String
+            successText: String,
+            hover: Boolean
         }
     },
     data() {

--- a/CodeCopy.vue
+++ b/CodeCopy.vue
@@ -6,7 +6,7 @@
             width="24"
             height="24"
             viewBox="0 0 24 24"
-            :class="hoverStyle"
+            :class="iconClass"
             :style="alignStyle"
         >
             <path fill="none" d="M0 0h24v24H0z" />
@@ -30,7 +30,7 @@ export default {
             backgroundTransition: Boolean,
             backgroundColor: String,
             successText: String,
-            onHover: Boolean
+            staticIcon: Boolean
         }
     },
     data() {
@@ -46,8 +46,8 @@ export default {
             style[this.options.align] = '7.5px'
             return style
         },
-        hoverStyle() {
-            return this.options.onHover ? 'hover' : ''
+        iconClass() {
+            return this.options.staticIcon ? '' : 'hover'
         }
     },
     methods: {
@@ -108,14 +108,14 @@ export default {
 svg {
     position: absolute;
     right: 7.5px;
-    opacity: 0.45;
+    opacity: 0.75;
     cursor: pointer;
 }
 
 svg.hover { opacity: 0 }
 
 svg:hover {
-    opacity: 1;
+    opacity: 1 !important;
 }
 
 span {
@@ -127,6 +127,6 @@ span {
 }
 
 .success {
-    opacity: 1;
+    opacity: 1 !important;
 }
 </style>

--- a/CodeCopy.vue
+++ b/CodeCopy.vue
@@ -30,7 +30,7 @@ export default {
             backgroundTransition: Boolean,
             backgroundColor: String,
             successText: String,
-            hover: Boolean
+            onHover: Boolean
         }
     },
     data() {
@@ -47,7 +47,7 @@ export default {
             return style
         },
         hoverStyle() {
-            return this.options.hover ? 'hover' : ''
+            return this.options.onHover ? 'hover' : ''
         }
     },
     methods: {

--- a/CodeCopy.vue
+++ b/CodeCopy.vue
@@ -6,6 +6,7 @@
             width="24"
             height="24"
             viewBox="0 0 24 24"
+            :class="hoverStyle"
             :style="alignStyle"
         >
             <path fill="none" d="M0 0h24v24H0z" />
@@ -44,6 +45,9 @@ export default {
             let style = {}
             style[this.options.align] = '7.5px'
             return style
+        },
+        hoverStyle() {
+            return this.options.hover ? 'hover' : ''
         }
     },
     methods: {
@@ -101,16 +105,14 @@ export default {
 </script>
 
 <style scoped>
-.code-copy {
-    opacity: 0;
-}
-
 svg {
     position: absolute;
     right: 7.5px;
     opacity: 0.45;
     cursor: pointer;
 }
+
+svg.hover { opacity: 0 }
 
 svg:hover {
     opacity: 1;

--- a/README.md
+++ b/README.md
@@ -82,3 +82,10 @@ This sets the color of the background transition animation and can take any [hex
 -   Default: `Copied!`
 
 This sets the text that displays when a user presses the copy button.
+
+### onHover
+
+-   Type: `Boolean`
+-   Default: `true`
+
+Copy icon is always visible or only visible when hovering over code block. 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ This sets the color of the background transition animation and can take any [hex
 
 This sets the text that displays when a user presses the copy button.
 
-### onHover
+### staticIcon
 
 -   Type: `Boolean`
--   Default: `true`
+-   Default: `false`
 
-Copy icon is always visible or only visible when hovering over code block. 
+Copy icon is only visible when hovering over code block or is always visible. 

--- a/clientRootMixin.js
+++ b/clientRootMixin.js
@@ -20,7 +20,7 @@ export default {
                         backgroundTransition: backgroundTransition,
                         backgroundColor: backgroundColor,
                         successText: successText,
-                        onHover: onHover
+                        staticIcon: staticIcon
                     }
                     instance.options = { ...options }
                     instance.code = el.innerText

--- a/clientRootMixin.js
+++ b/clientRootMixin.js
@@ -19,7 +19,8 @@ export default {
                         color: color,
                         backgroundTransition: backgroundTransition,
                         backgroundColor: backgroundColor,
-                        successText: successText
+                        successText: successText,
+                        hover: hover
                     }
                     instance.options = { ...options }
                     instance.code = el.innerText

--- a/clientRootMixin.js
+++ b/clientRootMixin.js
@@ -20,7 +20,7 @@ export default {
                         backgroundTransition: backgroundTransition,
                         backgroundColor: backgroundColor,
                         successText: successText,
-                        hover: hover
+                        onHover: onHover
                     }
                     instance.options = { ...options }
                     instance.code = el.innerText

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = (options = {}, ctx) => ({
         backgroundColor: options.backgroundColor || '#0075b8',
         backgroundTransition: options.backgroundTransition || true,
         successText: options.successText || 'Copied!',
-        hover: options.hover || true
+        onHover: options.onHover !== false
     },
     enhanceAppFiles: [path.resolve(__dirname, 'appFile.js')],
     clientRootMixin: path.resolve(__dirname, 'clientRootMixin.js')

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ module.exports = (options = {}, ctx) => ({
         backgroundColor: options.backgroundColor || '#0075b8',
         backgroundTransition: options.backgroundTransition !== false,
         successText: options.successText || 'Copied!',
-        onHover: options.onHover !== false
+        staticIcon: options.staticIcon === true
+
     },
     enhanceAppFiles: [path.resolve(__dirname, 'appFile.js')],
     clientRootMixin: path.resolve(__dirname, 'clientRootMixin.js')

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = (options = {}, ctx) => ({
         align: options.align || 'bottom',
         color: options.color || '#27b1ff',
         backgroundColor: options.backgroundColor || '#0075b8',
-        backgroundTransition: options.backgroundTransition || true,
+        backgroundTransition: options.backgroundTransition !== false,
         successText: options.successText || 'Copied!',
         onHover: options.onHover !== false
     },

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ module.exports = (options = {}, ctx) => ({
         color: options.color || '#27b1ff',
         backgroundColor: options.backgroundColor || '#0075b8',
         backgroundTransition: options.backgroundTransition || true,
-        successText: options.successText || 'Copied!'
+        successText: options.successText || 'Copied!',
+        hover: options.hover || true
     },
     enhanceAppFiles: [path.resolve(__dirname, 'appFile.js')],
     clientRootMixin: path.resolve(__dirname, 'clientRootMixin.js')

--- a/style.css
+++ b/style.css
@@ -1,3 +1,3 @@
-.code-copy-added:hover>.code-copy {
+.code-copy-added:hover>.code-copy svg {
     opacity: 1;
 }

--- a/style.css
+++ b/style.css
@@ -1,3 +1,3 @@
 .code-copy-added:hover>.code-copy svg {
-    opacity: 1;
+    opacity: .75;
 }


### PR DESCRIPTION
Hi Nicholas! We're working on a documentation project and needed this copy button to remain static (instead of only showing when a user hovers over the code). I added the 'onHover' option/setting to allow users the choice. Hope that's helpful!